### PR TITLE
readme, enable params for fetchdata route

### DIFF
--- a/.env sample
+++ b/.env sample
@@ -1,0 +1,1 @@
+INFURA_URL=https://mainnet.infura.io/v3/your_infura_key

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,50 @@
 ## Web3 indexer, built in Rust
+
+API that Fetches event logs for specified contract address and block range.
+
+## Pre-requisites
+
+need .env file which contains infura url for ethereum mainnet
+`cargo run` will run the app
+
+use postman to call the endpoint `localhost:8000/fetchdata`
+
+provide params for target_address, start_block, end_block. eg:
+`http://localhost:8000/fetchdata?start_block=18277200&end_block=18277210&target_address=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`
+
+## What it does right now
+
+rocket web framework is used to host the api
+
+### fetch (event) data
+
+the route fetchdata fetches event logs from a specified block range.
+the function for this route initiates a new tokio run time.
+
+Test successful for small range of blocks. multiple api requests done simultaneously.
+
+```
+GET /fetchdata?start_block=18277200&end_block=18277210&target_address=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2:
+    => Matched: GET /fetchdata?<target_address>&<start_block>&<end_block> (fetchdata)
+spawning task for blocks 18277200 to 18277202
+spawning task for blocks 18277203 to 18277205
+spawning task for blocks 18277206 to 18277208
+spawning task for blocks 18277209 to 18277210
+# matching entries: 139
+# matching entries: 237
+# matching entries: 153
+# matching entries: 113
+    => Outcome: Success
+    => Response succeeded.
+
+```
+
+For large range, would need to ...
+
+- deal with returning large data set: paginate results? or save to a file and return ipfs address?
+- use a db to cache block info to save on API requests
+  - structure all APIs to read from db by default. only trigger API calls if needed.
+
+For usability
+
+- try to decode event data, if ABI is easily obtained. eg. etherscan

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,12 +79,15 @@ impl<'r> Responder<'r> for ApiError {
 
 
 
-#[get("/fetchdata")]
-fn fetchdata() -> Either<Json<Vec<Log>>, ApiError> {
+#[get("/fetchdata?<target_address>&<start_block>&<end_block>")]
+fn fetchdata(target_address: String,
+    start_block: u64,
+    end_block: u64
+) -> Either<Json<Vec<Log>>, ApiError> {
     let runtime = tokio::runtime::Runtime::new().unwrap();
-    let target_address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string().to_lowercase();
-    let start_block = 18277200;
-    let end_block = 18277210;
+    // let target_address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string().to_lowercase();
+    // let start_block = 18277200;
+    // let end_block = 18277210;
 
     let result = runtime.block_on(fetch_chain_data(start_block, end_block, target_address));
 


### PR DESCRIPTION
**In this PR:**

- Modified fetchdata route to take on params for contract address & start/end block
- Readme explains current state of this project, thoughts on next steps for fetching event data


**About the initial commit prior to this PR:**
- Got tokio to work together with rocket. Was having all sorts of run time issues before that (eg. async not compatible with rocket).  Solution was to create new tokio run time when fetchdata route was called. 
- chain_data.rs handles the actual API calls using infura API
- main.rs. has the api using rocket
